### PR TITLE
Feature/admin interface

### DIFF
--- a/public/css/queue.css
+++ b/public/css/queue.css
@@ -29,6 +29,10 @@
     display: none !important;
 }
 
+.notSuper .superOnly {
+    display: none !important;
+}
+
 #schedulePicker .scheduleUnit {
     display: block;
     margin: 2px;

--- a/public/queue.html
+++ b/public/queue.html
@@ -53,7 +53,7 @@
 
     <!-- Hi Mom! All operations are validated on the serverside. Don't waste your time. :) -->
 
-    <body>
+    <body class="notSuper">
         <script>
             function onSignIn(googleUser) {
                 Bundle.onSignIn(googleUser);
@@ -67,6 +67,9 @@
                     data-onsuccess="onSignIn"
                     data-theme="dark"
                 ></div>
+            </div>
+            <div>
+                <button type="button" class="btn btn-info superOnly" data-toggle="modal" data-target="#createCourseDialog">Create Course</button>
             </div>
             <h5 id="accountMessage" class="text-danger"></h5>
         </div>
@@ -246,7 +249,7 @@
                                 <label
                                     class="control-label col-sm-2"
                                     for="signUpLocation"
-                                    >Location:</label
+                                    >Meeting Link:</label
                                 >
                                 <div class="col-sm-10">
                                     <input
@@ -255,7 +258,7 @@
                                         id="signUpLocation"
                                         required="required"
                                         maxlength="100"
-                                        placeholder="e.g. Computer #36, laptop by glass/atrium door, etc."
+                                        placeholder=""
                                     />
                                 </div>
                             </div>
@@ -424,7 +427,7 @@
             </div>
         </div>
 
-        <!-- modal dialog for modifying a queue schedule -->
+        <!-- modal dialog for modifying queue configuration -->
         <div id="manageQueueDialog" class="modal fade adminOnly" role="dialog">
             <div class="modal-dialog modal-lg">
                 <!-- Modal content-->
@@ -641,6 +644,185 @@
                             <div id="appt-schedule-picker-container">
                                 <!-- pickers inserted by js -->
                             </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+
+        <!-- modal dialog for creating a new course -->
+        <div id="createCourseDialog" class="modal fade" role="dialog">
+            <div class="modal-dialog modal-lg">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button
+                            type="button"
+                            class="close"
+                            data-dismiss="modal"
+                        >
+                            &times;
+                        </button>
+                        <h4 class="modal-title">Create Course</h4>
+                    </div>
+                    <div class="modal-body">
+                        <form id="createCourseForm" role="form">
+                            <div>
+                                <label>
+                                    Short Name
+                                </label>
+                                <input
+                                    id="shortNameInput"
+                                    type="text"
+                                    required="required"
+                                    maxlength="30"
+                                    placeholder="e.g. EECS 280"
+                                />
+                            </div>
+                            <div>
+                                <label>
+                                    Full Name
+                                </label>
+                                <input
+                                    id="fullNameInput"
+                                    type="text"
+                                    required="required"
+                                    maxlength="200"
+                                    placeholder="e.g. Programming and Introductory Data Structures"
+                                />
+                            </div>
+                            <button
+                                id="createCourseButton"
+                                type="submit"
+                                class="btn btn-default"
+                            >
+                                Create Course
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+        <!-- modal dialog for creating a new queue -->
+        <div id="createQueueDialog" class="modal fade" role="dialog">
+            <div class="modal-dialog modal-lg">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button
+                            type="button"
+                            class="close"
+                            data-dismiss="modal"
+                        >
+                            &times;
+                        </button>
+                        <h4 class="modal-title">Add a Queue to this Course</h4>
+                    </div>
+                    <div class="modal-body">
+                        <form id="createQueueForm" role="form">
+                            <div>
+                                Type:
+                                <br />
+                                <input type="radio" id="queueTypeOrderedInput" name="type" value="ordered" />
+                                <label for="queueTypeOrderedInput">Ordered</label>
+                                <br />
+                                <input type="radio" id="queueTypeAppointmentsInput" name="type" value="appointments" />
+                                <label for="queueTypeAppointmentsInput">Appointments</label>
+                            </div>
+                            <div>
+                                <label>
+                                    Name
+                                </label>
+                                <input
+                                    name="name"
+                                    type="text"
+                                    required="required"
+                                    maxlength="100"
+                                    placeholder="e.g. Office Hours"
+                                />
+                            </div>
+                            <div>
+                                <label>
+                                    Location
+                                </label>
+                                <input
+                                    name="location"
+                                    type="text"
+                                    required="required"
+                                    maxlength="100"
+                                    placeholder="e.g. Duderstadt Basement, Online, etc."
+                                />
+                            </div>
+                            <div>
+                                <label>
+                                    Map File Name (leave blank for no map)
+                                </label>
+                                <input
+                                    name="map"
+                                    type="text"
+                                    maxlength="100"
+                                    placeholder="e.g. duderstadt_basement.png"
+                                />
+                            </div>
+                            <div>
+                                <label>
+                                    Currently Active? (set this to true)
+                                </label>
+                                <input
+                                    name="active"
+                                    type="text"
+                                    required="required"
+                                    placeholder="true, false"
+                                    pattern="true|false"
+                                />
+                            </div>
+                            <button
+                                id="createQueueButton"
+                                type="submit"
+                                class="btn btn-default"
+                            >
+                                Add Queue
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+        
+        <!-- modal dialog for editing course staff -->
+        <div id="editStaffDialog" class="modal fade" role="dialog">
+            <div class="modal-dialog modal-lg">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button
+                            type="button"
+                            class="close"
+                            data-dismiss="modal"
+                        >
+                            &times;
+                        </button>
+                        <h4 class="modal-title">Edit Course Staff</h4>
+                    </div>
+                    <div class="modal-body">
+                        <form id="editStaffForm" role="form">
+                            <div>
+                                Course Staff (newline separated emails):
+                                <br />
+                                <textarea name="staff" rows="10" cols="20" style="resize:none"></textarea>
+                            </div>
+                            <button
+                                type="submit"
+                                class="btn btn-default"
+                            >
+                                <span><span class="glyphicon glyphicon-floppy-saved"></span> Saved</span>
+                            </button>
                         </form>
                     </div>
                 </div>

--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"strings"
@@ -120,5 +121,49 @@ func (s *Server) Login() http.HandlerFunc {
 
 		session.Values["email"] = email
 		s.sessions.Save(r, w, session)
+	}
+}
+
+type getAdminCourses interface {
+	GetAdminCourses(ctx context.Context, email string) ([]string, error)
+}
+
+type getUserInfo interface {
+	siteAdmin
+	getAdminCourses
+}
+
+func (s *Server) GetCurrentUserInfo(gi getUserInfo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		email := r.Context().Value(emailContextKey).(string)
+
+		admin, err := gi.SiteAdmin(r.Context(), email)
+		if err != nil {
+			s.logger.Errorw("failed to get site admin status",
+				RequestIDContextKey, r.Context().Value(RequestIDContextKey),
+				"email", email,
+			)
+			s.internalServerError(w, r)
+			return
+		}
+
+		courses, err := gi.GetAdminCourses(r.Context(), email)
+		if err != nil {
+			s.logger.Errorw("failed to get admin courses",
+				RequestIDContextKey, r.Context().Value(RequestIDContextKey),
+				"email", email,
+				"err", err,
+			)
+			s.internalServerError(w, r)
+			return
+		}
+
+		resp := struct {
+			Email        string   `json:"email"`
+			SiteAdmin    bool     `json:"site_admin"`
+			AdminCourses []string `json:"admin_courses"`
+		}{email, admin, courses}
+
+		s.sendResponse(http.StatusOK, resp, w, r)
 	}
 }

--- a/server/api/course.go
+++ b/server/api/course.go
@@ -91,28 +91,6 @@ func (s *Server) GetCourse(gc getCourse) http.HandlerFunc {
 	}
 }
 
-type getAdminCourses interface {
-	GetAdminCourses(ctx context.Context, email string) ([]string, error)
-}
-
-func (s *Server) GetAdminCourses(gc getAdminCourses) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		email := r.Context().Value(emailContextKey).(string)
-		courses, err := gc.GetAdminCourses(r.Context(), email)
-		if err != nil {
-			s.logger.Errorw("failed to get admin courses",
-				RequestIDContextKey, r.Context().Value(RequestIDContextKey),
-				"email", email,
-				"err", err,
-			)
-			s.internalServerError(w, r)
-			return
-		}
-
-		s.sendResponse(http.StatusOK, courses, w, r)
-	}
-}
-
 type getQueues interface {
 	getCourse
 	GetQueues(ctx context.Context, course ksuid.KSUID) ([]*Queue, error)

--- a/server/api/routes.go
+++ b/server/api/routes.go
@@ -24,6 +24,7 @@ type Server struct {
 type queueStore interface {
 	siteAdmin
 	queueAdmin
+	getUserInfo
 
 	getCourses
 	getCourse
@@ -132,9 +133,6 @@ func New(q queueStore, logger *zap.SugaredLogger, sessionsStore *sql.DB) *Server
 				r.Delete("/", s.RemoveCourseAdmins(q))
 			})
 		})
-
-		// Get courses on which the current user is an admin
-		r.With(s.ValidLoginMiddleware).Get("/admin/@me", s.GetAdminCourses(q))
 	})
 
 	// Queue by ID endpoints
@@ -274,6 +272,8 @@ func New(q queueStore, logger *zap.SugaredLogger, sessionsStore *sql.DB) *Server
 
 	// Login handler (takes Google idtoken, sets up session)
 	s.Post("/login", s.Login())
+
+	s.With(s.ValidLoginMiddleware).Get("/users/@me", s.GetCurrentUserInfo(q))
 
 	s.NotFound(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/src/js/AppointmentsQueue.ts
+++ b/src/js/AppointmentsQueue.ts
@@ -1,4 +1,4 @@
-import { Page } from './Queue';
+import { Page } from './queue';
 import { Course, QueueApplication, User } from './QueueApplication';
 import { oops, showErrorMessage, Mutable, assert } from './util/util';
 import $ from 'jquery';

--- a/src/js/OrderedQueue.ts
+++ b/src/js/OrderedQueue.ts
@@ -495,7 +495,7 @@ export class SignUpForm<HasAppointments extends boolean = false> {
                         .append(
                             '<label class="control-label col-sm-3" for="signUpLocation' +
                                 this._inst_id +
-                                '">Location:</label>',
+                                `">Meeting Link:</label>`,
                         )
                         .append(
                             $('<div class="col-sm-9"></div>').append(

--- a/src/js/OrderedQueue.ts
+++ b/src/js/OrderedQueue.ts
@@ -502,7 +502,7 @@ export class SignUpForm<HasAppointments extends boolean = false> {
                                 (this.signUpLocationInput = $(
                                     '<input type="text" class="form-control" id="signUpLocation' +
                                         this._inst_id +
-                                        '"required="required" maxlength="100" placeholder="e.g. Computer #36, laptop by glass/atrium door, etc.">',
+                                        '"required="required" maxlength="100" placeholder="">',
                                 )),
                             ),
                         ),

--- a/src/js/OrderedQueue.ts
+++ b/src/js/OrderedQueue.ts
@@ -7,7 +7,7 @@ import {
     Message,
 } from './util/mixins';
 import { oops, showErrorMessage, Mutable, asMutable } from './util/util';
-import { Page } from './Queue';
+import { Page } from './queue';
 import $ from 'jquery';
 import moment, { max, Moment } from 'moment-timezone';
 

--- a/src/js/OrderedQueue.ts
+++ b/src/js/OrderedQueue.ts
@@ -530,7 +530,7 @@ export class SignUpForm<HasAppointments extends boolean = false> {
                         ` form-group"><div class="col-sm-offset-3 col-sm-9">
                     <button type="submit" class="btn btn-success queue-signUpButton">${this.signUpButtonContent.signUp}</button> 
                     <button type="submit" class="btn btn-success queue-updateRequestButton" style="display:none;"></button>
-                    <button type="button" class="btn btn-danger queue-removeRequestButton" data-toggle="modal" data-target="#removeMyAppointmentDialog" style="display:none;"></button>
+                    <!-- <button type="button" class="btn btn-danger queue-removeRequestButton" data-toggle="modal" data-target="#removeMyAppointmentDialog" style="display:none;"></button> -->
                     </div></div>`,
                 )),
         );

--- a/src/js/OrderedQueue.ts
+++ b/src/js/OrderedQueue.ts
@@ -418,7 +418,7 @@ export class SignUpForm<HasAppointments extends boolean = false> {
     private mapY?: number;
     private appointmentsSlotsTable: JQuery;
     private appointmentHeaderElems?: readonly JQuery[];
-    private appointmentHeaderElemsMap: { [index: number]: JQuery } = {};
+    private appointmentHeaderElemsMap: { [index: number]: JQuery | undefined} = {};
     private selectedTimeslot?: number;
     private signUpButtons: JQuery;
     private updateRequestButtons: JQuery;
@@ -831,18 +831,19 @@ export class SignUpForm<HasAppointments extends boolean = false> {
     }
 
     private setSelectedTimeslot(this: SignUpForm<true>, timeslot: number) {
-        this.selectedTimeslot &&
-            this.appointmentHeaderElemsMap[this.selectedTimeslot].removeClass(
+        if (this.selectedTimeslot !== undefined) {
+            this.appointmentHeaderElemsMap[this.selectedTimeslot]?.removeClass(
                 'appointment-slots-header-selected',
             );
+        }
         this.selectedTimeslot = timeslot;
         this.myRequest &&
             this.myRequest.timeslot !== timeslot &&
-            this.appointmentHeaderElemsMap[this.myRequest.timeslot].addClass(
+            this.appointmentHeaderElemsMap[this.myRequest.timeslot]?.addClass(
                 'appointment-slots-header-cancel',
             );
         this.appointmentHeaderElemsMap[timeslot]
-            .removeClass('appointment-slots-header-cancel')
+            ?.removeClass('appointment-slots-header-cancel')
             .addClass('appointment-slots-header-selected');
     }
 
@@ -1363,7 +1364,7 @@ export function filterAppointmentsSchedule(appointments: AppointmentSchedule) {
             (i !== 0 && appointments[i - 1].numAvailable > 0),
     );
     // if last filtered appointment is empty, pop it
-    if (appointments[appointments.length - 1].numAvailable === 0) {
+    if (appointments.length > 0 && appointments[appointments.length - 1].numAvailable === 0) {
         appointments.pop();
     }
     return appointments;

--- a/src/js/QueueApplication.ts
+++ b/src/js/QueueApplication.ts
@@ -6,7 +6,7 @@ import { Observable, MessageResponses, messageResponse } from './util/mixins';
 import escape from 'lodash/escape';
 import endsWith from 'lodash/endsWith';
 import { Mutable, oops, showErrorMessage } from './util/util';
-import { QueueKind, Page } from './Queue';
+import { QueueKind, Page } from './queue';
 import { OrderedQueue } from './OrderedQueue';
 import { AppointmentsQueue } from './AppointmentsQueue';
 import $ from 'jquery';

--- a/src/js/QueueApplication.ts
+++ b/src/js/QueueApplication.ts
@@ -27,6 +27,7 @@ export class QueueApplication {
     private coursePanes: JQuery;
 
     private courses: Course[] = [];
+    public readonly activeCourse?: Course;
     private _activePage?: Page;
 
     private messagesShown: { [index: string]: boolean } = {};
@@ -93,8 +94,9 @@ export class QueueApplication {
             let course = new Course(courseData, courseElem);
             this.courses.push(course);
 
-            pillElem.find('a').click(function () {
+            pillElem.find('a').click(() => {
                 course.makeActive();
+                (<Mutable<this>>this).activeCourse = course;
             });
         });
     }
@@ -122,6 +124,14 @@ export class QueueApplication {
     }
 
     public userSignedIn() {
+
+        if (User.isSuper()) {
+            $("body").removeClass("notSuper");
+        }
+        else {
+            $("body").addClass("notSuper");
+        }
+
         this.courses.forEach((course) => {
             course.userSignedIn();
         });
@@ -196,6 +206,13 @@ export class QueueApplication {
             }
         }
     }
+
+    public createCourse(courseSpec: NewCourseSpecification) {
+        return fetch("api/courses/", {
+            method: "POST",
+            body: JSON.stringify(courseSpec)
+        });
+    }
 }
 
 export class Course {
@@ -206,6 +223,8 @@ export class Course {
     private isAdmin: boolean = false;
     private queues: any[] = [];
     private activeQueue: any;
+
+    private readonly courseAdminControls: CourseAdminControls;
 
     private readonly elem: JQuery;
     private readonly queuePillsElem: JQuery;
@@ -220,6 +239,10 @@ export class Course {
         this.fullName = data['full_name'];
 
         this.elem = elem;
+
+        this.courseAdminControls = new CourseAdminControls(
+            this, $('<div></div>').appendTo(this.elem)
+        );
 
         this.queuePillsElem = $('<ul class="queuePills nav nav-pills"></ul>');
         this.elem.append(this.queuePillsElem);
@@ -347,6 +370,200 @@ export class Course {
             queue.userSignedIn();
         });
     }
+
+    public createQueue(queueSpec: NewQueueSpecification) {
+        return fetch(`api/courses/${this.courseId}/queues`, {
+            method: "POST",
+            body: JSON.stringify(queueSpec)
+        });
+    }
+    
+    public getStaff() {
+        return fetch(`api/courses/${this.courseId}/admins`, {
+            method: "GET"
+        });
+    }
+
+    public setStaff(staffSpec: CourseStaffSpecification) {
+        
+        // filter to unique staff
+        staffSpec = Array.from(new Set(staffSpec));
+
+        return fetch(`api/courses/${this.courseId}/admins`, {
+            method: "PUT",
+            body: JSON.stringify(staffSpec)
+        });
+    }
+}
+
+class CourseAdminControls {
+    private course: Course;
+    private elem: JQuery;
+
+    constructor(course: Course, elem: JQuery) {
+        this.course = course;
+        this.elem = elem.addClass("adminOnly");
+
+        this.elem.append('<p><b>Course Admin</b></p>');
+
+        this.elem.append('<button type=" button" class="btn btn-info adminOnly" data-toggle="modal" data-target="#createQueueDialog">Create Queue</button>');
+        this.elem.append(" ");
+        this.elem.append('<button type=" button" class="btn btn-info adminOnly" data-toggle="modal" data-target="#editStaffDialog">Edit Course Staff</button>');
+
+        this.elem.append('<hr />')
+    }
+}
+
+interface NewCourseSpecification {
+    readonly short_name: string;
+    readonly full_name: string;
+}
+
+export class CreateCourseDialog {
+
+    public constructor() {
+        let createCourseForm = $('#createCourseForm');
+        createCourseForm.submit(async (e) => {
+            e.preventDefault();
+            
+            try {
+                let response = await QueueApplication.instance.createCourse({
+                    short_name: ""+$("#shortNameInput").val(),
+                    full_name: ""+$("#fullNameInput").val()
+                });
+
+                if (!response.ok) {
+                    showErrorMessage(JSON.parse(await response.text()));
+                }
+            }
+            catch(e) {
+                showErrorMessage(e);
+            }
+            $('#createCourseDialog').modal('hide');
+        });
+    }
+
+}
+
+
+
+interface NewQueueSpecification {
+    readonly type: QueueKind;
+    readonly name: string;
+    readonly location: string;
+    readonly map: string;
+    readonly active: boolean;
+}
+
+export class CreateQueueDialog {
+
+    public constructor() {
+        let createQueueForm = $('#createQueueForm');
+        createQueueForm.submit(async (e) => {
+            e.preventDefault();
+            
+            try {
+                let response = await QueueApplication.instance.activeCourse!.createQueue({
+                    type: <QueueKind>(""+$('#createQueueForm input[name="type"]:checked').val()),
+                    name: ""+$('#createQueueForm input[name="name"]').val(),
+                    location: ""+$('#createQueueForm input[name="location"]').val(),
+                    map: ""+$('#createQueueForm input[name="map"]').val(),
+                    active: "true" === $('#createQueueForm input[name="active"]').val(),
+                });
+
+                if (!response.ok) {
+                    showErrorMessage(JSON.parse(await response.text()));
+                }
+            }
+            catch(e) {
+                showErrorMessage(e);
+            }
+            $('#createQueueDialog').modal('hide');
+        });
+    }
+
+}
+
+
+type CourseStaffSpecification = readonly string[];
+
+export class EditStaffDialog {
+
+    private static readonly STAFF_UP_TO_DATE =
+        '<span><span class="glyphicon glyphicon-floppy-saved"></span> Saved</span>';
+    private static readonly STAFF_UNSAVED =
+        '<span><span class="glyphicon glyphicon-floppy-open"></span> Update Staff</span>';
+
+    private updateStaffButton: JQuery;
+
+    public constructor() {
+        this.updateStaffButton = $("#editStaffForm button:submit");
+
+        $("#editStaffDialog").on('shown.bs.modal', () => {
+            this.refresh();
+        });
+
+        $('#editStaffForm textarea[name="staff"]')
+            .on("keyup", () => { this.unsavedChanges(); return true; });
+
+        $("#editStaffForm").submit(async (e) => {
+            e.preventDefault();
+            
+            try {
+                let response = await QueueApplication.instance.activeCourse!.setStaff(
+                    (""+$('#editStaffForm textarea[name="staff"]').val()).split("\n").map((s) => s.trim())
+                );
+
+                if (response.ok) {
+                    this.changesUpToDate();
+                }
+                else {
+                    showErrorMessage(JSON.parse(await response.text()));
+                }
+            }
+            catch(e) {
+                showErrorMessage(e);
+            }
+            $('#createQueueDialog').modal('hide');
+        });
+    }
+
+    private async refresh() {
+        try {
+            let response = await QueueApplication.instance.activeCourse!.getStaff();
+
+            if (response.ok) {
+                $('#editStaffForm textarea[name="staff"]').val(
+                    JSON.parse((await response.text())).join("\n")
+                );
+                this.changesUpToDate();
+            }
+            else {
+                $('#createQueueDialog').modal('hide');
+                showErrorMessage(JSON.parse(await response.text()));
+            }
+        }
+        catch(e) {
+            showErrorMessage(e);
+            $('#createQueueDialog').modal('hide');
+        }
+    }
+
+    private unsavedChanges() {
+        this.updateStaffButton
+            .html(EditStaffDialog.STAFF_UNSAVED)
+            .prop('disabled', false)
+            .removeClass('btn-success')
+            .addClass('btn-warning');
+    }
+
+    private changesUpToDate() {
+        this.updateStaffButton
+            .html(EditStaffDialog.STAFF_UP_TO_DATE)
+            .prop('disabled', true)
+            .removeClass('btn-warning')
+            .addClass('btn-success');
+    }
 }
 
 export namespace User {
@@ -402,6 +619,10 @@ export namespace User {
         return theUser.isMe(email);
     }
 
+    export function isSuper() {
+        return theUser.isSuper;
+    }
+
     export function email() {
         return theUser.email;
     }
@@ -414,6 +635,7 @@ export namespace User {
         public abstract isCourseAdmin(courseId: string): boolean;
         public abstract isMe(email: string): boolean;
         public abstract readonly email?: string;
+        public abstract readonly isSuper?: boolean;
 
         public onSignOut() {
             // nothing to do here for now
@@ -431,7 +653,8 @@ export namespace User {
     class AuthenticatedUser extends UserBase {
         public readonly email: string;
         private readonly _idToken: string;
-        private admins: { [index: string]: boolean } = {};
+        private admin_courses: { [index: string]: boolean } = {};
+        public readonly isSuper?: boolean;
 
         constructor(email: string, idtoken: string) {
             super();
@@ -473,17 +696,20 @@ export namespace User {
         private checkAdmin(): void {
             $.ajax({
                 type: 'GET',
-                url: 'api/courses/admin/@me',
+                url: 'api/users/@me',
                 dataType: 'json',
                 success: (data) => {
-                    for (var i = 0; i < data.length; ++i) {
-                        this.admins[data[i]] = true;
+                    (<Mutable<this>>this).isSuper = data["site_admin"];
+
+                    let admin_courses: readonly string[] = data["admin_courses"];
+                    for (var i = 0; i < admin_courses.length; ++i) {
+                        this.admin_courses[admin_courses[i]] = true;
                     }
 
                     // TODO HACK If admin for anything, give them fast refresh
                     // should only be on the queues they administer
                     // also if admin prompt for notifications
-                    if (data.length > 0) {
+                    if (admin_courses.length > 0) {
                         setInterval(function () {
                             QueueApplication.instance.refreshActivePage();
                         }, 5000);
@@ -511,11 +737,14 @@ export namespace User {
         }
 
         public isCourseAdmin(courseId: string): boolean {
-            return this.admins[courseId];
+            return this.admin_courses[courseId];
         }
     }
 
     class UnauthenticatedUser extends UserBase {
+
+        public readonly isSuper = false;
+
         constructor() {
             super();
 

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -1,4 +1,4 @@
-import { QueueApplication, User } from './QueueApplication';
+import { QueueApplication, User, CreateCourseDialog, CreateQueueDialog, EditStaffDialog } from './QueueApplication';
 import { Schedule, ManageQueueDialog, OrderedQueue } from './OrderedQueue';
 import $ from 'jquery';
 import 'bootstrap3/dist/js/bootstrap.js';
@@ -99,6 +99,9 @@ function setupDialogs() {
     new Schedule($('#schedulePicker'));
 
     new ManageQueueDialog();
+    new CreateCourseDialog();
+    new CreateQueueDialog();
+    new EditStaffDialog();
 
     let removeMyAppointmentInput = $('#removeMyAppointmentInput');
     let removeMyAppointmentDialog = $('#removeMyAppointmentDialog');

--- a/src/js/util/util.ts
+++ b/src/js/util/util.ts
@@ -53,6 +53,10 @@ export function oops(xhr: any, textStatus?: any) {
 }
 
 export function showErrorMessage(message: any) {
+    if (message.message) {
+        showErrorMessage(message.message);
+        return;
+    }
     console.log(message);
     $('#errorMessage').html(message);
     $('#errorDialog').modal('show');


### PR DESCRIPTION
This PR adds an admin interface to tie into some of the new api endpoints for course and queue management.

An "add course" button and dialog is available for site admins.

A new "course admin" panel is added to each course, which is visible only to course admins. It contains an "add queue" button/dialog, as well as a button/dialog for editing course staff.

This PR also fixes a random case inconsistency and a front end bug/crash when there were no appointments on the current day.